### PR TITLE
add SeqFeature store class for Gene Level Copy Number Track

### DIFF
--- a/gdc-viewer/js/Store/SeqFeature/GeneLevelCopyNumber.js
+++ b/gdc-viewer/js/Store/SeqFeature/GeneLevelCopyNumber.js
@@ -1,0 +1,33 @@
+/**
+ * GeneLevelCopyNumber store class
+ * Supports (Data format, Data category, Data Type)
+ * * TXT, Copy Number Variation, Gene Level Copy Number
+ */
+define([
+    'dojo/_base/declare',
+    './BaseBEDLikeFeature',
+],
+function (
+    declare,
+    BaseBEDLikeFeature
+) {
+    return declare(BaseBEDLikeFeature, {
+        convertLineToBED: function(line) {
+            originalLine = line.split('\t');
+
+            bedLikeLine = [originalLine[2].replace('chr', '')];  // chr
+            bedLikeLine.push(originalLine[3]);  // start
+            bedLikeLine.push(originalLine[4]);  // end
+            bedLikeLine.push(originalLine[1]);  // name
+            bedLikeLine.push(originalLine[5]);  // score
+            bedLikeLine.push(null);  // strand
+
+            fullLine = bedLikeLine.concat(originalLine);
+            return fullLine.join('\t');
+        },
+
+        getName: function() {
+            return 'GeneLevelCopyNumber'
+        }
+    })
+})


### PR DESCRIPTION
Main issue: #63

Looked into best way to display track and each of XYPlot & HTMLFeatures have their advantages.

I'd say using both types together would be ideal to both see the copy numbers at a high-level (XYPlot) and be able to click in to see more gene info (HTMLFeatures).