### PR TITLE
only access just-the-docs remotely

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -32,4 +32,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
-gem "just-the-docs"
+gem "jekyll-remote-theme"
+gem "rake"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -29,16 +29,17 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-remote-theme (0.4.2)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.3.2)
-      jekyll (>= 3.8.5)
-      jekyll-seo-tag (~> 2.0)
-      rake (>= 12.3.1, < 13.1.0)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -61,6 +62,7 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.4)
     rouge (3.23.0)
+    rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -74,10 +76,11 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.9.0)
   jekyll-feed (~> 0.13.0)
-  just-the-docs
+  jekyll-remote-theme
   kramdown (>= 2.3.0)
   kramdown-parser-gfm
   minima (~> 2.5.1)
+  rake
   tzinfo-data
 
 BUNDLED WITH

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,10 +21,10 @@ url: "https://lincolnsteinlab.github.io/gdc-viewer" # the base hostname & protoc
 
 # Build settings
 markdown: kramdown
-theme: just-the-docs
-remote_theme: pmarsceill/just-the-docs
+remote_theme: pmarsceill/just-the-docs@v0.3.2
 plugins:
   - jekyll-feed
+  - jekyll-remote-theme
 
 aux_links:
   "GDC Viewer on GitHub":


### PR DESCRIPTION
Docs site has issues caused by specifying theme twice in `_config.yml`. Hopefully only using the theme should fix this.