### PR TITLE
bump JBrowse 1.16.6 -> 1.16.10 (Dockerfile)

### DIFF
--- a/cypress/integration/ExploreGDC.js
+++ b/cypress/integration/ExploreGDC.js
@@ -121,7 +121,7 @@ describe('Explore GDC', function() {
         })
 
         checkAllResultsTab(
-            ['Showing 1 to 20 of 3,127', 'TCGA-A5-A1OF', 'TCGA-AJ-A3EK'],
+            ['Showing 1 to 20 of 3,129', 'TCGA-A5-A1OF', 'TCGA-AJ-A3EK'],
             ['Showing 1 to 20 of 21,316', 'TTN', 'TP53'],
             ['Showing 1 to 20 of 132,784', 'chr7:g.140753336A>T', 'chr2:g.208248388C>T']
         )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="andrew.duncan@oicr.on.ca"
 
 ARG plugin_version=develop
 
-ENV JBROWSE_VERSION 1.16.6
+ENV JBROWSE_VERSION 1.16.10
 ENV PLUGIN_VERSION=$plugin_version
 
 # Install dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:latest
 
-LABEL maintainer="andrew.duncan@oicr.on.ca"
+LABEL maintainer="gregory.hogue@oicr.on.ca"
 
 ARG plugin_version=develop
 
@@ -27,7 +27,8 @@ RUN git clone https://github.com/LincolnSteinLab/gdc-viewer /gdc-viewer/ && \
     cat ./data/jbrowse.conf > /jbrowse/jbrowse.conf
 
 # Setup JBrowse
-RUN ./setup.sh
+RUN yarn install && \
+    yarn build
 
 # Expose port 3000
 EXPOSE 3000


### PR DESCRIPTION
We should be on the latest version. Also Travis builds started failing and will probably get fixed with this commit https://github.com/GMOD/jbrowse/commit/e89b44758f1109f015928e65f7a1d3a3d6d7e3ee#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17