### PR TITLE
Support already working GDC filetypes (open-access) with byFileId UI

### DIFF
--- a/gdc-viewer/js/Store/SeqFeature/BaseBEDLikeFeature.js
+++ b/gdc-viewer/js/Store/SeqFeature/BaseBEDLikeFeature.js
@@ -8,7 +8,7 @@ define([
     'JBrowse/Store/SeqFeature/BED',
     './BedLikeParser',
     'JBrowse/Store/SeqFeature',
-    'JBrowse/Model/XHRBlob',
+    'gdc-viewer/Model/XHRBlob',
     'JBrowse/Model/BlobFilehandleWrapper'
 ],
 function(
@@ -24,7 +24,7 @@ function(
     return declare([ SeqFeatureStore, BED ], {
         /**
          * Constructor
-         * @param {*} args 
+         * @param {*} args
          */
         constructor: function (args) {
             this.data = new BlobFilehandleWrapper(

--- a/gdc-viewer/js/Store/SeqFeature/GeneLevelCopyNumber.js
+++ b/gdc-viewer/js/Store/SeqFeature/GeneLevelCopyNumber.js
@@ -1,6 +1,7 @@
 /**
  * GeneLevelCopyNumber store class
  * Supports (Data format, Data category, Data Type)
+ * * TSV, Copy Number Variation, Gene Level Copy Number
  * * TXT, Copy Number Variation, Gene Level Copy Number
  */
 define([

--- a/gdc-viewer/js/Store/SeqFeature/MethylationBetaValue.js
+++ b/gdc-viewer/js/Store/SeqFeature/MethylationBetaValue.js
@@ -1,7 +1,7 @@
 /**
  * MethylationBetaValue store class
  * Supports (Data format, Data category, Data Type)
- * * TXT, DNA Methlyation, Methylation Beta Value
+ * * TXT, DNA Methylation, Methylation Beta Value
  */
 define([
     'dojo/_base/declare',

--- a/gdc-viewer/js/Store/SeqFeature/SEG.js
+++ b/gdc-viewer/js/Store/SeqFeature/SEG.js
@@ -1,9 +1,9 @@
 /**
  * SEG store class for CopyNumberSegment files
  * Supports (Data format, Data category, Data Type)
- * * TXT, Copy number variation, Copy number Segment
- * * TXT, Copy number variation, Masked copy number Segment
- * * TXT, Copy number variation, Allele-specific copy number Segment
+ * * TXT, Copy Number Variation, Copy Number Segment
+ * * TXT, Copy Number Variation, Masked Copy Number Segment
+ * * TXT, Copy Number Variation, Allele-specific Copy Number Segment
  */
 define([
     'dojo/_base/declare',

--- a/gdc-viewer/js/View/GDCByFileIdDialog.js
+++ b/gdc-viewer/js/View/GDCByFileIdDialog.js
@@ -278,6 +278,38 @@ function (
                     missing.push('bai');
                 }
 
+            } else if (file.data_format == "TSV") {
+                trackConf['key'] += "TSV_";
+                if (file.data_category == "Transcriptome Profiling") {
+                    if (file.data_type == "Isoform Expression Quantification") {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/IsoformExpressionQuantification';
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
+                    }
+                }
+
+            } else if (file.data_format == "TXT") {
+                trackConf['key'] += "TXT_";
+                if (file.data_category == "Copy number variation") {
+                    if ([
+                        "Copy number Segment",
+                        "Masked copy number Segment",
+                        "Allele-specific copy number Segment"
+                    ].indexOf(file.data_type) >= 0) {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/SEG';
+                        trackConf['type'] = 'JBrowse/View/Track/Wiggle/XYPlot';
+
+                    } else if (file.data_type == "Gene Level Copy Number") {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/GeneLevelCopyNumber';
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
+                    }
+
+                } else if (file.data_category == "DNA Methylation") {
+                    if (file.data_type == "Methylation Beta Value") {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/MethylationBetaValue';
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';  // TODO: compare with XYPlot
+                    }
+                }
+
             } else if (file.data_format == "VCF") {
                 trackConf['key'] += "VCF_";
                 storeConf['type'] = 'gdc-viewer/Store/SeqFeature/VCFTabix';

--- a/gdc-viewer/js/View/GDCByFileIdDialog.js
+++ b/gdc-viewer/js/View/GDCByFileIdDialog.js
@@ -235,7 +235,13 @@ function (
 
             var link = dom.create('a', { innerHTML: "View on the GDC", target: "_blank", href: "https://portal.gdc.cancer.gov/files/" + file.file_id }, results);
 
-            var {storeConf, trackConf, missing} = this.getFileConf(file);
+            fileConf = this.getFileConf(file);
+            if (fileConf == null) {
+                return;
+            }
+            var {storeConf, trackConf, missing} = fileConf;
+
+            var missingProps = dom.create('div', { innerHTML: "Missing Properties: " + missing }, results);
 
             if (missing.length == 0) {
                 new Button({
@@ -285,15 +291,21 @@ function (
                         storeConf['type'] = 'gdc-viewer/Store/SeqFeature/IsoformExpressionQuantification';
                         trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
                     }
+
+                } else if (file.data_category == "Copy Number Variation") {
+                    if (file.data_type == "Gene Level Copy Number") {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/GeneLevelCopyNumber';
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
+                    }
                 }
 
             } else if (file.data_format == "TXT") {
                 trackConf['key'] += "TXT_";
-                if (file.data_category == "Copy number variation") {
+                if (file.data_category == "Copy Number Variation") {
                     if ([
-                        "Copy number Segment",
-                        "Masked copy number Segment",
-                        "Allele-specific copy number Segment"
+                        "Copy Number Segment",
+                        "Masked Copy Number Segment",
+                        "Allele-specific Copy Number Segment"
                     ].indexOf(file.data_type) >= 0) {
                         storeConf['type'] = 'gdc-viewer/Store/SeqFeature/SEG';
                         trackConf['type'] = 'JBrowse/View/Track/Wiggle/XYPlot';
@@ -306,7 +318,13 @@ function (
                 } else if (file.data_category == "DNA Methylation") {
                     if (file.data_type == "Methylation Beta Value") {
                         storeConf['type'] = 'gdc-viewer/Store/SeqFeature/MethylationBetaValue';
-                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';  // TODO: compare with XYPlot
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
+                    }
+
+                } else if (file.data_category == "Transcriptome Profiling") {
+                    if (file.data_type == "Isoform Expression Quantification") {
+                        storeConf['type'] = 'gdc-viewer/Store/SeqFeature/IsoformExpressionQuantification';
+                        trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
                     }
                 }
 
@@ -327,6 +345,11 @@ function (
                     delete trackConf['urlTemplate'];
                     missing.push('file');
                 }
+
+            }
+
+            if (!('type' in trackConf)) {
+                return null;
             }
 
             trackConf['store'] = this.browser.addStoreConfig(null, storeConf);


### PR DESCRIPTION
Main ticket: #92 

This makes life much easier for viewing all currently supported files.
Only gives the option to "Add Track" for supported files with all requirements met (indexed BAM/VCF, GZipped VCF, etc.).

Verified all types working - ideally we'll have tests in the future.

Implementation for types may need to be refactored / moved soon since it will continue to get longer.