### PR TITLE
add support for MAF files

### DIFF
--- a/gdc-viewer/js/Store/SeqFeature/MAF.js
+++ b/gdc-viewer/js/Store/SeqFeature/MAF.js
@@ -26,7 +26,7 @@ function(
     return declare(SkipLastCtor(BaseBEDLikeFeature, 2), {
 
         constructor: function(args) {
-            this.inherited(arguments);
+            this.inherited(arguments);  // super()
 
             if (args.maf) {
                 this.data = new BlobFilehandleWrapper(args.maf);
@@ -42,11 +42,6 @@ function(
                 throw new Error('must provide either `maf` or `urlTemplate`');
             }
 
-            this.features = [];
-            this._loadFeatures();
-        },
-
-        _loadFeatures: function() {
             // Override fetchLines() from JBrowse/Model/FileBlob
             this.data.fetchLines = (lineCallback, endCallback, failCallback) => {
                 this.data.readFile().then(unzip).then((array) => {  // gunzip
@@ -56,7 +51,7 @@ function(
                     });
                     let line;
                     while (line = lineIterator.getline()) {
-                        if (line.length == 0 || line[0] == '#') {
+                        if (line.length == 0 || line[0] == '#') {  // skip header
                             continue;
                         }
                         lineCallback(line);
@@ -64,7 +59,9 @@ function(
                     endCallback();
                 }).catch(failCallback);
             };
-            this.inherited(arguments);
+
+            this.features = [];
+            this._loadFeatures();
         },
 
         convertLineToBED: function(line) {

--- a/gdc-viewer/js/Store/SeqFeature/MAF.js
+++ b/gdc-viewer/js/Store/SeqFeature/MAF.js
@@ -1,0 +1,88 @@
+const { unzip } = cjsRequire('@gmod/bgzf-filehandle');
+/**
+ * MAF store class
+ * Supports (Data format, Data category, Data Type)
+ * * MAF, Simple Nucleotide Variation, Aggregated Somatic Mutation
+ * * MAF, Simple Nucleotide Variation, Annotated Somatic Mutation
+ * * MAF, Simple Nucleotide Variation, Masked Aggregated Somatic Mutation
+ * * MAF, Simple Nucleotide Variation, Masked Annotated Somatic Mutation
+ */
+define([
+    'dojo/_base/declare',
+    'gdc-viewer/Model/XHRBlob',
+    'gdc-viewer/Store/SeqFeature/BaseBEDLikeFeature',
+    'gdc-viewer/Util/SkipLastCtor',
+    'JBrowse/Model/BlobFilehandleWrapper',
+    'JBrowse/Util/TextIterator'
+],
+function(
+    declare,
+    XHRBlob,
+    BaseBEDLikeFeature,
+    SkipLastCtor,
+    BlobFilehandleWrapper,
+    TextIterator
+) {
+    return declare(SkipLastCtor(BaseBEDLikeFeature, 2), {
+
+        constructor: function(args) {
+            this.inherited(arguments);
+
+            if (args.maf) {
+                this.data = new BlobFilehandleWrapper(args.maf);
+            } else if (args.urlTemplate) {
+                this.data = new BlobFilehandleWrapper(
+                    new XHRBlob(
+                        this.resolveUrl(
+                            args.urlTemplate
+                        )
+                    )
+                );
+            } else {
+                throw new Error('must provide either `maf` or `urlTemplate`');
+            }
+
+            this.features = [];
+            this._loadFeatures();
+        },
+
+        _loadFeatures: function() {
+            // Override fetchLines() from JBrowse/Model/FileBlob
+            this.data.fetchLines = (lineCallback, endCallback, failCallback) => {
+                this.data.readFile().then(unzip).then((array) => {  // gunzip
+                    const lineIterator = new TextIterator.FromBytes({
+                        bytes: array,
+                        returnPartialRecord: true
+                    });
+                    let line;
+                    while (line = lineIterator.getline()) {
+                        if (line.length == 0 || line[0] == '#') {
+                            continue;
+                        }
+                        lineCallback(line);
+                    }
+                    endCallback();
+                }).catch(failCallback);
+            };
+            this.inherited(arguments);
+        },
+
+        convertLineToBED: function(line) {
+            const originalLine = line.split('\t');
+
+            var bedLikeLine = [originalLine[4].replace('chr', '')];  // chr
+            bedLikeLine.push(originalLine[5]);  // start
+            bedLikeLine.push(originalLine[6]);  // end
+            bedLikeLine.push(originalLine[0]);  // name
+            bedLikeLine.push(null);  // score
+            bedLikeLine.push(originalLine[7]);  // strand
+
+            const fullLine = bedLikeLine.concat(originalLine);
+            return fullLine.join('\t');
+        },
+
+        getName: function() {
+            return 'MAF';
+        }
+    })
+})

--- a/gdc-viewer/js/Util/SkipLastCtor.js
+++ b/gdc-viewer/js/Util/SkipLastCtor.js
@@ -8,7 +8,7 @@ define( [
 // Creates a subclass of T that skips T's constructor, but none of T's parents'.
 // This effectively allows rewriting T's constructor without code duplication.
 // Useful for tweaking classes from base JBrowse.
-return function(T) {
+return function(T, nSkip=1) {
     return declare('SkipLastCtor', T, {
         '-chains-': {
             constructor: 'manual'
@@ -22,7 +22,7 @@ return function(T) {
                 ctor = ctor._meta.parents;
             }
             const bases = ctor._meta.bases;
-            for (var idx = bases.length - 1; idx > 0; idx--) {
+            for (var idx = bases.length - 1; idx >= nSkip; idx--) {
                 bases[idx]._meta.ctor.apply(this, arguments);
             }
         }

--- a/gdc-viewer/js/View/GDCByFileIdDialog.js
+++ b/gdc-viewer/js/View/GDCByFileIdDialog.js
@@ -241,7 +241,9 @@ function (
             }
             var {storeConf, trackConf, missing} = fileConf;
 
-            var missingProps = dom.create('div', { innerHTML: "Missing Properties: " + missing }, results);
+            if (missing.length > 0) {
+                dom.create('div', { innerHTML: "Missing Properties: " + missing }, results);
+            }
 
             if (missing.length == 0) {
                 new Button({
@@ -283,6 +285,11 @@ function (
                 } else {
                     missing.push('bai');
                 }
+
+            } else if (file.data_format == "MAF") {
+                trackConf['key'] += "MAF_";
+                storeConf['type'] = 'gdc-viewer/Store/SeqFeature/MAF';
+                trackConf['type'] = 'JBrowse/View/Track/HTMLFeatures';
 
             } else if (file.data_format == "TSV") {
                 trackConf['key'] += "TSV_";


### PR DESCRIPTION
Main ticket: #81

This is our first time dealing directly with a gzipped filetype from GDC (without falling back to JBrowse modules)!

MAF files unzipped are basically TSVs with a multi-line #-commented header.

I was able to use @gmod/bgzf-filehandle to unzip the MAF & then leverage our BaseBEDLikeFeature Store class.