### PR TITLE
use setup.sh in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,8 +27,7 @@ RUN git clone https://github.com/LincolnSteinLab/gdc-viewer /gdc-viewer/ && \
     cat ./data/jbrowse.conf > /jbrowse/jbrowse.conf
 
 # Setup JBrowse
-RUN yarn install && \
-    yarn build
+RUN ./setup.sh
 
 # Expose port 3000
 EXPOSE 3000


### PR DESCRIPTION
JBrowse 1.16.11 fixes https://github.com/GMOD/jbrowse/issues/1555
Can revert back to using setup.sh